### PR TITLE
fixed bug with json serialization of events...

### DIFF
--- a/src/test/groovy/EiffelactoryTest.groovy
+++ b/src/test/groovy/EiffelactoryTest.groovy
@@ -1,24 +1,6 @@
-import groovy.json.JsonOutput
-import groovy.json.JsonSlurper
-import org.jfrog.artifactory.client.ArtifactoryClientBuilder
 import spock.lang.Specification
 
 class EiffelactoryTest extends Specification {
-    def 'plugin is executed'() {
-        setup:
-            def baseUrl = "http://localhost:8081/artifactory"
-            def artifactory = ArtifactoryClientBuilder.create()
-                    .setUrl(baseUrl)
-                    .setUsername("admin")
-                    .setPassword("password").build()
-
-        when:
-            def json = new JsonSlurper().parseText(artifactory.plugins().execute('eiffelactory').sync())
-
-        then:
-            json.status == 'ok'
-    }
-
     def 'eiffel artifact published event is correctly constructed'() {
         setup:
         def tags = new ArrayList<String>()


### PR DESCRIPTION
Fixed bug with json serialization of events
RabbitMQHelper is now used in a static context
Added publish function and removed sender loop
An EiffelArtifactPublishedEvent with repo path as location is created in storage -> afterCreate callback